### PR TITLE
Fix InfiniteDataView bottomBuffer height calculation

### DIFF
--- a/src/main/java/gwt/material/design/client/data/AbstractDataView.java
+++ b/src/main/java/gwt/material/design/client/data/AbstractDataView.java
@@ -229,7 +229,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
         Range visibleRange = getVisibleRange();
 
         // Check if we need to redraw categories
-        if(redrawCategories) {
+        if(isUseCategories() && redrawCategories) {
             redrawCategories = false;
 
             // When we perform a category redraw we have

--- a/src/main/java/gwt/material/design/client/data/infinite/InfiniteDataView.java
+++ b/src/main/java/gwt/material/design/client/data/infinite/InfiniteDataView.java
@@ -224,7 +224,7 @@ public class InfiniteDataView<T> extends AbstractDataView<T> {
         bufferTop.height(topHeight);
 
         int categoryMod = isUseCategories() ? categories.size() : 0;
-        int bottomHeight = ((totalRows + categoryMod) * calcRowHeight) - (topHeight - calcRowHeight);
+        int bottomHeight = ((totalRows + categoryMod - viewSize - indexOffset) * calcRowHeight) - (topHeight - calcRowHeight);
         bufferBottom.height(bottomHeight);
 
         super.render(components);


### PR DESCRIPTION
1. Fixes an extra DOM manipulations (this.rows.clearElements() in Abstract DataView.renderRows) , when categories are not used.

2. Fixes InfiniteDataView.bottomBuffer size calculation on rows redraw after scroll. Without this change bottomBuffer always equals total height of all rows and adds extra space for scroll. This is not correct for case when total number of rows are known on the server side at the grid rendering time, and InfiniteDataView are used to replace pager.