### PR TITLE
Show "y of z" in pager actionLabel when page has only 1 record

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/pager/MaterialDataPager.java
+++ b/src/main/java/gwt/material/design/client/ui/pager/MaterialDataPager.java
@@ -197,9 +197,10 @@ public class MaterialDataPager<T> extends MaterialDataPagerBase<T> implements Ha
      */
     protected void updateUi() {
 
-        // Action label (current selection)
+        // Action label (current selection) in either the form "x-y of z" or "y of z" (when page has only 1 record)
+        int firstRow = offset + 1;
         int lastRow = (isExcess() & isLastPage()) ? totalRows : (offset + limit);
-        actionLabel.setText((offset + 1) + "-" + lastRow + " of " + totalRows);
+        actionLabel.setText((firstRow == lastRow ? lastRow : firstRow + "-" + lastRow) + " of " + totalRows);
 
         // Build the currentPage number listbox
         listPages.clear();


### PR DESCRIPTION
When current page has only one record, actionLabel will display "y of z" instead of "y-y of z"