### PR TITLE
Prevent sending smaller limit value to the datasource for the last page

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/pager/MaterialDataPager.java
+++ b/src/main/java/gwt/material/design/client/ui/pager/MaterialDataPager.java
@@ -165,18 +165,20 @@ public class MaterialDataPager<T> extends MaterialWidget implements HasPager {
     protected void doLoad(int offset, int limit) {
         this.offset = offset;
 
-        // Check whether the pager has excess rows with given limit
-        if (isLastPage() & isExcess()) {
-            // Get the difference between total rows and excess rows
-            limit = totalRows - offset;
-        }
-
-        int finalLimit = limit;
         dataSource.load(new LoadConfig<>(offset, limit, table.getView().getSortContext(),
                 table.getView().getOpenCategories()), new LoadCallback<T>() {
             @Override
             public void onSuccess(LoadResult<T> loadResult) {
                 totalRows = loadResult.getTotalLength();
+                
+                int finalLimit = limit;
+                
+                // Check whether the pager has excess rows with given limit
+                if (isLastPage() & isExcess()) {
+                  // Get the difference between total rows and excess rows
+                  finalLimit = totalRows - offset;
+                }
+                
                 table.setVisibleRange(offset, finalLimit);
                 table.loaded(loadResult.getOffset(), loadResult.getData());
                 updateUi();


### PR DESCRIPTION
Reduced limit for the last page should be only passed to table.setVisibleRange method, not for dataSource.load(...).