### PR TITLE
Enhance performance with tables with large number of pages.

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/pager/PageNumberSelection.java
+++ b/src/main/java/gwt/material/design/client/ui/pager/PageNumberSelection.java
@@ -65,7 +65,8 @@ public class PageNumberSelection extends MaterialWidget implements HasValue<Inte
         listPages.clear();
         int pages = (pager.isExcess()) ? (totalRows / limit) + 1 : totalRows / limit;
         for (int i = 1; i <= pages; i++) {
-            listPages.addItem(i);
+            // Do not reload for each item. Below setSelectedIndex reloads
+            listPages.addItem(i, false);
         }
         listPages.setSelectedIndex(currentPage - 1);
     }


### PR DESCRIPTION
Fix bad performance by not reloading the page-selection drop-down constantly when building it, but rather reload it after adding all the pages.
Fixes #148